### PR TITLE
remove absolute path /usr/bin/squidclient

### DIFF
--- a/plugins/squid/agents/squid
+++ b/plugins/squid/agents/squid
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-echo "<<<check_squid>>>"
-/usr/bin/squidclient -p 3128 -T2 mgr:5min | grep =
+if type squidclient > /dev/null 2>&1 ; then
+   echo "<<<check_squid>>>"
+   squidclient -p 3128 -T2 mgr:5min | grep =
+fi


### PR DESCRIPTION
in some cases squidclient is located in /usr/sbin/squidclient (for example in SuSE SLES11)
