### PR TITLE
Puppet4 has no longer the space at the end of the line

### DIFF
--- a/plugins/puppet/agents/plugins/linux/mk_puppet
+++ b/plugins/puppet/agents/plugins/linux/mk_puppet
@@ -5,6 +5,6 @@ if [ -e "${LASTRUN}" ]; then
   OUT="$(cat ${LASTRUN} | sed 's/[[:space:]]\{2,\}//g')"
   echo "<<<check_puppet_agent>>>"
   echo "${OUT}" | grep 'last_run'
-  echo "${OUT}" | grep -A8 '^resources: $' | sed 's/^/resources_/g'
-  echo "${OUT}" | grep -A3 '^events: $' | sed 's/^/events_/g'
+  echo "${OUT}" | grep -A8 '^resources: *$' | sed 's/^/resources_/g'
+  echo "${OUT}" | grep -A3 '^events: *$' | sed 's/^/events_/g'
 fi


### PR DESCRIPTION
Puppet 4 does not has the space after resources: and events:
To make it compatible for both Puppet 3 and 4 I've added the * to the regexp so that it can be 0 or more spaces behind the:

Also consider the new Puppet4 location of this report it is:
LASTRUN="/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml"
However that would break backward compatibility and I leave that up to you to change or leave it as is.
Thank you for the package!