### PR TITLE
Adding a space in line 14 to EOF

### DIFF
--- a/plugins/check_bind9/checkman/check_bind9
+++ b/plugins/check_bind9/checkman/check_bind9
@@ -9,13 +9,13 @@ description:
  Before install the plugin, you must edit and the query_log variable to reflect the
  query_log file path of named.conf.
 
-If you want "queries persecond" information, you must configure your named.conf like this:
+ If you want "queries persecond" information, you must configure your named.conf like this:
 
-channel "query_log" {
-  file "/var/log/query.log" versions 10 size 100m;
-  severity info;
-  print-time yes;
-};
-category queries { "query_log"; };
+ channel "query_log" {
+   file "/var/log/query.log" versions 10 size 100m;
+   severity info;
+   print-time yes;
+ };
+ category queries { "query_log"; };
 
-And change the "agent/plugin/isc_bind9" to reflect the "query_log" file location.
+ And change the "agent/plugin/isc_bind9" to reflect the "query_log" file location.


### PR DESCRIPTION
Check_mk fails listing the plugins after installing the check_bind9. Adding spaces on the lines specified resolves the problems.